### PR TITLE
Enable email verification on API key signup form

### DIFF
--- a/sam/key.md
+++ b/sam/key.md
@@ -14,7 +14,8 @@ nav: key
     exampleApiUrl: 'https://api.data.gov/sam/v1/registrations/1459697830000?api_key={{api_key}}',
     contactUrl: 'https://github.com/GSA/GSA-APIs/issues',
     siteName: 'SAM.gov',
-    emailFromName: 'SAM.gov Developer Hub'
+    emailFromName: 'SAM.gov Developer Hub',
+    verifyEmail: true
   };
 
   /* * * DON'T EDIT BELOW THIS LINE * * */


### PR DESCRIPTION
Following up on our e-mail conversation, this is the remaining step needed to require e-mail verification for accessing your API. If you merge this, then your API key signup form should change behavior so the API keys are not immediately displayed to the user in their browser, but instead are only e-mailed to them (thus verifying their e-mail address).

Apologies this option is a bit buried right (it's described in the [embedding docs](https://github.com/18F/api.data.gov/wiki/User-Manual:-Agencies#embedding-the-api-key-signup-form-on-your-own-documentation-site)), but we'll see about adding a more explicit section on the steps needed to enable e-mail verification.